### PR TITLE
Fix for issue #20

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!bash
+#!/bin/bash
 #Checking for root
 if [[ "$EUID" -ne 0 ]]; then
   echo "Please run as root, so sudo password isn't required later on..."


### PR DESCRIPTION
[This issue](https://github.com/LethalEthan/Bluetooth-Unlock/issues/20) is caused by an incorrect shebang at the beginning of the install.sh script. I've fixed it in this branch.