### PR TITLE
Replace pybluez from Pip with python3-bluez from APT

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,8 +44,7 @@ elif [[ -n "$(echo $release | grep -i Debian)" ]]; then
   echo "Using APT on Debian!"
   echo "WARNING: This hasn't been tested on a Debian system, it may not work!"
   sudo apt-get update
-  sudo apt-get install -y python3 python3-pip bluetooth libbluetooth-dev tar || installfail=1
-  sudo -H -u $USER python3 -m pip install pybluez || bluedepfail=1
+  sudo apt-get install -y python3 python3-bluez bluetooth libbluetooth-dev tar || installfail=1
   echo "Install complete! please run Bluetooth-Unlock.py"
 
 #Install for blackPanther


### PR DESCRIPTION
On Debian Bookworm, in a Conda environment providing Python 3.9.12, it was not possible to install the pybluez package. The error message was

    Preparing metadata (setup.py) ... error
    error: subprocess-exited-with-error

    × python setup.py egg_info did not run successfully.
    │ exit code: 1
    ╰─> [1 lines of output]
        error in PyBluez setup command: use_2to3 is invalid.
        [end of output]

Since the same package is provided by `python3-bluez` in APT, one can switch to that. It seems preferable to stick with the distribution's package, since this guarantees a functional setup script throughout the lifetime of the distribution.